### PR TITLE
treat Hootenanny hostname param like a hostname

### DIFF
--- a/osm_export_tool/__init__.py
+++ b/osm_export_tool/__init__.py
@@ -4,7 +4,7 @@ from enum import Enum
 from shapely.geometry import shape, MultiPolygon, Polygon
 
 name = 'osm_export_tool'
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 
 class GeomType(Enum):
     POINT = 1

--- a/osm_export_tool/sources.py
+++ b/osm_export_tool/sources.py
@@ -597,7 +597,7 @@ class Hootenanny:
             'hoot', 'convert', '-D', 'overpass.api.query.path={0}'.format(tmp.name),
                                '-D', 'bounds={0}'.format(geom),
                                '-D', 'reader.http.bbox.max.download.size={0}'.format(self.maxGridSize), # override api read limit
-                                self.hostname, temp_pbf
+                                os.path.join(self.hostname, 'api', 'interpreter'), temp_pbf
         ])
 
         for ext in self.extensions:


### PR DESCRIPTION
wrote this so Hootenanny class' hostname param needs to be `${overpass_host}/api/interpreter`.
that param should just be a hostname like the param and other classes suggest. Then in the `fetch` method concatenante the `/api/interpreter` pathname.