### PR TITLE
Use hoot streaming reader

### DIFF
--- a/osm_export_tool/sources.py
+++ b/osm_export_tool/sources.py
@@ -231,7 +231,7 @@ class Overpass:
             subprocess.check_call(['curl','-X','POST','-d','@'+os.path.join(self.tempdir,'query.txt'),os.path.join(self.hostname,'api','interpreter'),'-o',self.tmp_path])
         else:
             with requests.post(os.path.join(self.hostname,'api','interpreter'),data=data, stream=True) as r:
-                
+
                 with open(self.tmp_path, 'wb') as f:
                     shutil.copyfileobj(r.raw, f)
 
@@ -258,7 +258,7 @@ class Overpass:
 
 class Galaxy:
     """Transfers Yaml Language to Galaxy Query Make a request and sends response back from fetch()"""
-    
+
     @classmethod
     def hdx_filters(cls,t):
         geometryType=[]
@@ -279,7 +279,7 @@ class Galaxy:
             ways_select_filter=cls.attribute_filter(t)
             line_columns=cls.attribute_filter(t)
 
-            geometryType.append("line") # Galaxy supports both linestring and multilinestring, getting them both since export tool only has line but with galaxy it will also deliver multilinestring features 
+            geometryType.append("line") # Galaxy supports both linestring and multilinestring, getting them both since export tool only has line but with galaxy it will also deliver multilinestring features
             for part in parts:
                 part_dict=json.loads(f"""{'{'}{part.strip()}{'}'}""")
                 for key,value in part_dict.items():
@@ -300,7 +300,7 @@ class Galaxy:
                             if value == [] : # if incoming value is not null i.e. key = * ignore previously added values
                                 poly_filter[key] = value
                             else:
-                                poly_filter[key] += value # if value was not previously = * then and value is not =* then add values 
+                                poly_filter[key] += value # if value was not previously = * then and value is not =* then add values
 
         if point_filter:
             point_filter=cls.remove_duplicates(point_filter)
@@ -310,15 +310,15 @@ class Galaxy:
             poly_filter=cls.remove_duplicates(poly_filter)
         return point_filter,line_filter,poly_filter,geometryType,point_columns,line_columns,poly_columns
 
-    
+
     @classmethod
     def filters(cls,mapping):
         geometryType=[]
         point_filter,line_filter,poly_filter={},{},{}
         point_columns,line_columns,poly_columns=[],[],[]
-        
+
         for t in mapping.themes:
-            
+
             parts = cls.parts(t.matcher.expr)
             if t.points:
                 point_columns=cls.attribute_filter(t)
@@ -334,7 +334,7 @@ class Galaxy:
                 ways_select_filter=cls.attribute_filter(t)
                 line_columns=cls.attribute_filter(t)
 
-                geometryType.append("line") # Galaxy supports both linestring and multilinestring, getting them both since export tool only has line but with galaxy it will also deliver multilinestring features 
+                geometryType.append("line") # Galaxy supports both linestring and multilinestring, getting them both since export tool only has line but with galaxy it will also deliver multilinestring features
                 for part in parts:
                     part_dict=json.loads(f"""{'{'}{part.strip()}{'}'}""")
                     for key,value in part_dict.items():
@@ -355,7 +355,7 @@ class Galaxy:
                                 if value == [] : # if incoming value is not null i.e. key = * ignore previously added values
                                     poly_filter[key] = value
                                 else:
-                                    poly_filter[key] += value # if value was not previously = * then and value is not =* then add values 
+                                    poly_filter[key] += value # if value was not previously = * then and value is not =* then add values
 
         if point_filter:
             point_filter=cls.remove_duplicates(point_filter)
@@ -398,7 +398,7 @@ class Galaxy:
     def __init__(self,hostname,geom,mapping=None,file_name=""):
         self.hostname = hostname
         self.geom = geom
-        self.mapping = mapping  
+        self.mapping = mapping
         self.file_name=file_name
 
     def fetch(self,output_format,is_hdx_export=False):
@@ -411,16 +411,16 @@ class Galaxy:
             east = min(bounds[2], 180)
             north = min(bounds[3], 90)
             geom = '{1},{0},{3},{2}'.format(west, south, east, north)
-          
-        
+
+
         if self.mapping:
             if is_hdx_export:
                 fullresponse=[]
                 for t in self.mapping.themes:
                     point_filter,line_filter,poly_filter,geometryType_filter,point_columns,line_columns,poly_columns = Galaxy.hdx_filters(t)
                     osmTags=point_filter
-                    if point_filter == line_filter == poly_filter : 
-                        osmTags=point_filter # master filter that will be applied to all type of osm elements : current implementation of galaxy api 
+                    if point_filter == line_filter == poly_filter :
+                        osmTags=point_filter # master filter that will be applied to all type of osm elements : current implementation of galaxy api
                     else :
                         osmTags ={}
                     if point_columns == line_columns == poly_columns:
@@ -429,7 +429,7 @@ class Galaxy:
                         columns =[]
                     if len(geometryType_filter) == 0:
                         geometryType_filter=["point","line","polygon"]
-                    
+
                     for geomtype in geometryType_filter:
                         geomtype_to_pass=[geomtype]
                         if osmTags: # if it is a master filter i.e. filter same for all type of feature
@@ -460,13 +460,13 @@ class Galaxy:
                                     raise ValueError(r.content)
                         except requests.exceptions.RequestException as e:
                             raise e
-                            
+
                 return fullresponse
             else:
                 point_filter,line_filter,poly_filter,geometryType_filter,point_columns,line_columns,poly_columns = Galaxy.filters(self.mapping)
                 osmTags=point_filter
-                if point_filter == line_filter == poly_filter : 
-                    osmTags=point_filter # master filter that will be applied to all type of osm elements : current implementation of galaxy api 
+                if point_filter == line_filter == poly_filter :
+                    osmTags=point_filter # master filter that will be applied to all type of osm elements : current implementation of galaxy api
                 else :
                     osmTags ={}
                 if point_columns == line_columns == poly_columns:
@@ -475,7 +475,7 @@ class Galaxy:
                     columns =[]
         else:
             geometryType_filter=[] # if nothing is provided we are getting all type of data back
-        
+
         if osmTags: # if it is a master filter i.e. filter same for all type of feature
             if columns:
                 request_body={"fileName":self.file_name,"geometry":geom,"outputType":output_format,"geometryType":geometryType_filter,"filters":{"tags":{"all_geometry":osmTags},"attributes":{"all_geometry":columns}}}
@@ -548,7 +548,7 @@ class Hootenanny:
     def __init__(self,hostname,geom,path,use_existing=True,mapping=None,extensions=['shp'], name=None, schemas_config = {}, maxGridSize=1.0, out_type='xml'):
         if out_type not in self.valid_out_types:
             raise ValueError(
-                f'out_type {out_type} found in valid_out_types {",".join(self.valid_out_types)}'
+                f'out_type "{out_type}" found in valid_out_types {",".join(self.valid_out_types)}'
             )
 
         self.hostname = hostname

--- a/osm_export_tool/sources.py
+++ b/osm_export_tool/sources.py
@@ -231,7 +231,7 @@ class Overpass:
             subprocess.check_call(['curl','-X','POST','-d','@'+os.path.join(self.tempdir,'query.txt'),os.path.join(self.hostname,'api','interpreter'),'-o',self.tmp_path])
         else:
             with requests.post(os.path.join(self.hostname,'api','interpreter'),data=data, stream=True) as r:
-
+                
                 with open(self.tmp_path, 'wb') as f:
                     shutil.copyfileobj(r.raw, f)
 
@@ -258,7 +258,7 @@ class Overpass:
 
 class Galaxy:
     """Transfers Yaml Language to Galaxy Query Make a request and sends response back from fetch()"""
-
+    
     @classmethod
     def hdx_filters(cls,t):
         geometryType=[]
@@ -279,7 +279,7 @@ class Galaxy:
             ways_select_filter=cls.attribute_filter(t)
             line_columns=cls.attribute_filter(t)
 
-            geometryType.append("line") # Galaxy supports both linestring and multilinestring, getting them both since export tool only has line but with galaxy it will also deliver multilinestring features
+            geometryType.append("line") # Galaxy supports both linestring and multilinestring, getting them both since export tool only has line but with galaxy it will also deliver multilinestring features 
             for part in parts:
                 part_dict=json.loads(f"""{'{'}{part.strip()}{'}'}""")
                 for key,value in part_dict.items():
@@ -300,7 +300,7 @@ class Galaxy:
                             if value == [] : # if incoming value is not null i.e. key = * ignore previously added values
                                 poly_filter[key] = value
                             else:
-                                poly_filter[key] += value # if value was not previously = * then and value is not =* then add values
+                                poly_filter[key] += value # if value was not previously = * then and value is not =* then add values 
 
         if point_filter:
             point_filter=cls.remove_duplicates(point_filter)
@@ -310,15 +310,15 @@ class Galaxy:
             poly_filter=cls.remove_duplicates(poly_filter)
         return point_filter,line_filter,poly_filter,geometryType,point_columns,line_columns,poly_columns
 
-
+    
     @classmethod
     def filters(cls,mapping):
         geometryType=[]
         point_filter,line_filter,poly_filter={},{},{}
         point_columns,line_columns,poly_columns=[],[],[]
-
+        
         for t in mapping.themes:
-
+            
             parts = cls.parts(t.matcher.expr)
             if t.points:
                 point_columns=cls.attribute_filter(t)
@@ -334,7 +334,7 @@ class Galaxy:
                 ways_select_filter=cls.attribute_filter(t)
                 line_columns=cls.attribute_filter(t)
 
-                geometryType.append("line") # Galaxy supports both linestring and multilinestring, getting them both since export tool only has line but with galaxy it will also deliver multilinestring features
+                geometryType.append("line") # Galaxy supports both linestring and multilinestring, getting them both since export tool only has line but with galaxy it will also deliver multilinestring features 
                 for part in parts:
                     part_dict=json.loads(f"""{'{'}{part.strip()}{'}'}""")
                     for key,value in part_dict.items():
@@ -355,7 +355,7 @@ class Galaxy:
                                 if value == [] : # if incoming value is not null i.e. key = * ignore previously added values
                                     poly_filter[key] = value
                                 else:
-                                    poly_filter[key] += value # if value was not previously = * then and value is not =* then add values
+                                    poly_filter[key] += value # if value was not previously = * then and value is not =* then add values 
 
         if point_filter:
             point_filter=cls.remove_duplicates(point_filter)
@@ -398,7 +398,7 @@ class Galaxy:
     def __init__(self,hostname,geom,mapping=None,file_name=""):
         self.hostname = hostname
         self.geom = geom
-        self.mapping = mapping
+        self.mapping = mapping  
         self.file_name=file_name
 
     def fetch(self,output_format,is_hdx_export=False):
@@ -411,16 +411,16 @@ class Galaxy:
             east = min(bounds[2], 180)
             north = min(bounds[3], 90)
             geom = '{1},{0},{3},{2}'.format(west, south, east, north)
-
-
+          
+        
         if self.mapping:
             if is_hdx_export:
                 fullresponse=[]
                 for t in self.mapping.themes:
                     point_filter,line_filter,poly_filter,geometryType_filter,point_columns,line_columns,poly_columns = Galaxy.hdx_filters(t)
                     osmTags=point_filter
-                    if point_filter == line_filter == poly_filter :
-                        osmTags=point_filter # master filter that will be applied to all type of osm elements : current implementation of galaxy api
+                    if point_filter == line_filter == poly_filter : 
+                        osmTags=point_filter # master filter that will be applied to all type of osm elements : current implementation of galaxy api 
                     else :
                         osmTags ={}
                     if point_columns == line_columns == poly_columns:
@@ -429,7 +429,7 @@ class Galaxy:
                         columns =[]
                     if len(geometryType_filter) == 0:
                         geometryType_filter=["point","line","polygon"]
-
+                    
                     for geomtype in geometryType_filter:
                         geomtype_to_pass=[geomtype]
                         if osmTags: # if it is a master filter i.e. filter same for all type of feature
@@ -460,13 +460,13 @@ class Galaxy:
                                     raise ValueError(r.content)
                         except requests.exceptions.RequestException as e:
                             raise e
-
+                            
                 return fullresponse
             else:
                 point_filter,line_filter,poly_filter,geometryType_filter,point_columns,line_columns,poly_columns = Galaxy.filters(self.mapping)
                 osmTags=point_filter
-                if point_filter == line_filter == poly_filter :
-                    osmTags=point_filter # master filter that will be applied to all type of osm elements : current implementation of galaxy api
+                if point_filter == line_filter == poly_filter : 
+                    osmTags=point_filter # master filter that will be applied to all type of osm elements : current implementation of galaxy api 
                 else :
                     osmTags ={}
                 if point_columns == line_columns == poly_columns:
@@ -475,7 +475,7 @@ class Galaxy:
                     columns =[]
         else:
             geometryType_filter=[] # if nothing is provided we are getting all type of data back
-
+        
         if osmTags: # if it is a master filter i.e. filter same for all type of feature
             if columns:
                 request_body={"fileName":self.file_name,"geometry":geom,"outputType":output_format,"geometryType":geometryType_filter,"filters":{"tags":{"all_geometry":osmTags},"attributes":{"all_geometry":columns}}}


### PR DESCRIPTION
Providing hootenanny with `[out:json]` in an overpass query leads it to use a non-streamable json reader. As a result, the convert command ends up trying to buffer all the data it gets from the overpass query into memory before writing it out to a file. The xml reader can be "stream" the incoming data from overpass, so we want to use it.

This change allows the overpass output type to be chosen when the `Hootenanny` class is initialized. If no choice, parameter, is provided we default to xml.